### PR TITLE
Fix reference-count double-decrement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Makefile

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 Makefile
+**/built

--- a/app_swift.c
+++ b/app_swift.c
@@ -673,7 +673,6 @@ static int app_exec(struct ast_channel *chan, const char *data)
 	if (!res) {
 		ast_set_write_format(chan, old_writeformat);
 	}
-	ao2_cleanup(old_writeformat);
 #endif
 	ast_module_user_remove(u);
 	return res;


### PR DESCRIPTION
I am most definitely no Asterisk expert, so here I am just trying to be helpful...
The @darrensessions branch is totes broken on 13.
Your patch helps lots, but there was still a problem:
`ERROR[7669]: astobj2.c:131 INTERNAL_OBJ: FRACK!, Failed assertion bad magic number 0x0 for object ...`
I'd see that pretty much every time `Swift() `was called.  Sometimes it would crash _asterisk_.
It sure looks like old_format is being double-decremented, as the  RAII_VAR() setup should take care of the `ao2_cleanup`.  Removing the redundant  call seems to have indeed fixed the issue, but also renewed my suspicions of this code.  Right now the performance and interface just don't work for me compared to `Flite()` so I'm reverting, but wanted to share this observation in the hopes that it helps others.